### PR TITLE
Change Oauth values names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2 (October 28, 2019)
+
+* Change Oauth values naming
+
 ## 1.1.1 (July 10, 2019)
 
 * Add support for `Create Attachment` feature

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The component uses Salesforce - API Version 45.0, except:
 ### Authentication
 Authentication occurs via OAuth 2.0. 
 In the component repository you need to specify OAuth Client credentials as environment variables: 
-- ```SALESFORCE_KEY``` - your OAuth client key
-- ```SALESFORCE_SECRET``` - your OAuth client secret
+- ```OAUTH_CLIENT_ID``` - your OAuth client key
+- ```OAUTH_CLIENT_SECRET``` - your OAuth client secret
 
 ## Create new App in Salesforce
 

--- a/component.json
+++ b/component.json
@@ -4,11 +4,11 @@
   "docsUrl": "https://github.com/elasticio/salesforce-component",
   "url": "http://www.salesforce.com/",
   "envVars": {
-    "SALESFORCE_KEY": {
+    "OAUTH_CLIENT_ID": {
       "required": true,
       "description": "Your Salesforce OAuth client key"
     },
-    "SALESFORCE_SECRET": {
+    "OAUTH_CLIENT_SECRET": {
       "required": true,
       "description": "Your Salesforce OAuth client secret"
     },
@@ -17,6 +17,7 @@
       "description": "Salesforce API version to use for non deprecated methods. Default 45.0"
     }
   },
+  "useOAuthClient": true,
   "credentials": {
     "fields": {
       "prodEnv": {
@@ -36,8 +37,8 @@
       }
     },
     "oauth2": {
-      "client_id": "{{SALESFORCE_KEY}}",
-      "client_secret": "{{SALESFORCE_SECRET}}",
+      "client_id": "{{OAUTH_CLIENT_ID}}",
+      "client_secret": "{{OAUTH_CLIENT_SECRET}}",
       "auth_uri": "https://{{prodEnv}}.salesforce.com/services/oauth2/authorize",
       "token_uri": "https://{{prodEnv}}.salesforce.com/services/oauth2/token"
     }

--- a/lib/actions/lookup.js
+++ b/lib/actions/lookup.js
@@ -35,8 +35,8 @@ module.exports.process = async function processAction(message, configuration) {
   let res = [];
   const conn = new jsforce.Connection({
     oauth2: {
-      clientId: process.env.SALESFORCE_KEY,
-      clientSecret: process.env.SALESFORCE_SECRET,
+      clientId: process.env.OAUTH_CLIENT_ID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
       redirectUri: 'https://app.elastic.io/oauth/v2',
     },
     instanceUrl: configuration.oauth.instance_url,

--- a/lib/actions/lookupObject.js
+++ b/lib/actions/lookupObject.js
@@ -39,8 +39,8 @@ module.exports.process = async function processAction(message, configuration) {
   let res = [];
   const conn = new jsforce.Connection({
     oauth2: {
-      clientId: process.env.SALESFORCE_KEY,
-      clientSecret: process.env.SALESFORCE_SECRET,
+      clientId: process.env.OAUTH_CLIENT_ID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
       redirectUri: 'https://app.elastic.io/oauth/v2',
     },
     instanceUrl: configuration.oauth.instance_url,

--- a/lib/actions/query.js
+++ b/lib/actions/query.js
@@ -19,8 +19,8 @@ exports.process = function processAction(msg, conf) {
   console.log('Starting SOQL Select batchSize=%s query=%s', batchSize, msg.body.query);
   const conn = new jsforce.Connection({
     oauth2: {
-      clientId: process.env.SALESFORCE_KEY,
-      clientSecret: process.env.SALESFORCE_SECRET,
+      clientId: process.env.OAUTH_CLIENT_ID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
       redirectUri: 'https://app.elastic.io/oauth/v2'
     },
     instanceUrl: conf.oauth.instance_url,

--- a/lib/actions/upsert.js
+++ b/lib/actions/upsert.js
@@ -40,8 +40,8 @@ module.exports.process = function upsertObject(message, configuration) {
   console.log('Starting upsertObject');
   const conn = new jsforce.Connection({
     oauth2: {
-      clientId: process.env.SALESFORCE_KEY,
-      clientSecret: process.env.SALESFORCE_SECRET,
+      clientId: process.env.OAUTH_CLIENT_ID,
+      clientSecret: process.env.OAUTH_CLIENT_SECRET,
       redirectUri: 'https://app.elastic.io/oauth/v2',
     },
     instanceUrl: configuration.oauth.instance_url,

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -90,8 +90,8 @@ function SalesforceEntity(callScope) {
 
     const conn = new jsforce.Connection({
       oauth2: {
-        clientId: process.env.SALESFORCE_KEY,
-        clientSecret: process.env.SALESFORCE_SECRET,
+        clientId: process.env.OAUTH_CLIENT_ID,
+        clientSecret: process.env.OAUTH_CLIENT_SECRET,
         redirectUri: 'https://app.elastic.io/oauth/v2',
       },
       instanceUrl: cfg.oauth.instance_url,

--- a/lib/helpers/metaLoader.js
+++ b/lib/helpers/metaLoader.js
@@ -38,8 +38,8 @@ module.exports = class MetaLoader {
     this.SALESFORCE_API_VERSION = '39.0';
     this.connection = new jsforce.Connection({
       oauth2: {
-        clientId: process.env.SALESFORCE_KEY,
-        clientSecret: process.env.SALESFORCE_SECRET,
+        clientId: process.env.OAUTH_CLIENT_ID,
+        clientSecret: process.env.OAUTH_CLIENT_SECRET,
         redirectUri: 'https://app.elastic.io/oauth/v2',
       },
       instanceUrl: this.configuration.oauth.instance_url,

--- a/lib/triggers/streamPlatformEvents.js
+++ b/lib/triggers/streamPlatformEvents.js
@@ -33,8 +33,8 @@ function processTrigger(msg, cfg) {
     console.log('Trying to connect to jsforce...');
     conn = new jsforce.Connection({
       oauth2: {
-        clientId: process.env.SALESFORCE_KEY,
-        clientSecret: process.env.SALESFORCE_SECRET,
+        clientId: process.env.OAUTH_CLIENT_ID,
+        clientSecret: process.env.OAUTH_CLIENT_SECRET,
         redirectUri: 'https://app.elastic.io/oauth/v2',
       },
       instanceUrl: cfg.oauth.instance_url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-component",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salesforce-component",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "elastic.io component that connects to Salesforce API (node.js)",
   "main": "index.js",
   "scripts": {

--- a/verifyCredentials.js
+++ b/verifyCredentials.js
@@ -1,12 +1,21 @@
 const request = require('request');
+const fs = require('fs');
 
 const NOT_ENABLED_ERROR = 'Salesforce respond with this error: "The REST API is not enabled for this Organization."';
 const VERSION = 'v32.0';
 const debug = require('debug')('verifyCredentials');
 const debugToken = require('debug')('token');
 
+if (fs.existsSync('.env')) {
+  // eslint-disable-next-line global-require
+  require('dotenv').config();
+}
+
 // eslint-disable-next-line consistent-return
 module.exports = function verify(credentials, cb) {
+// eslint-disable-next-line no-use-before-define
+  checkOauth2EnvarsPresence();
+
   function checkResponse(err, response, body) {
     if (err) {
       return cb(err);
@@ -41,3 +50,14 @@ module.exports = function verify(credentials, cb) {
 
   request.get(options, checkResponse);
 };
+
+function checkOauth2EnvarsPresence() {
+  if (!process.env.OAUTH_CLIENT_ID) {
+    if (!process.env.OAUTH_CLIENT_SECRET) {
+      throw new Error('Environment variables are missed: OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET');
+    }
+    throw new Error('Environment variables are missed: OAUTH_CLIENT_ID');
+  } else if (!process.env.OAUTH_CLIENT_SECRET) {
+    throw new Error('Environment variables are missed: OAUTH_CLIENT_SECRET');
+  }
+}


### PR DESCRIPTION
Platform has functionality "oAuth client". To make it work all oAuth components should use standardized naming for the envVars with key and secret:
OAUTH_CLIENT_ID
OAUTH_CLIENT_SECRE